### PR TITLE
fix: restore custom title bars on panel windows

### DIFF
--- a/Views/Panels/BasePanelWindow.axaml
+++ b/Views/Panels/BasePanelWindow.axaml
@@ -2,6 +2,7 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="using:vTFMS.ViewModels.Panels"
         xmlns:local="using:vTFMS.Converters"
+        xmlns:panels="using:vTFMS.Views.Panels"
         x:Class="vTFMS.Views.Panels.BasePanelWindow"
         x:DataType="vm:BasePanelViewModel"
         Background="{StaticResource PanelBackgroundBrush}"
@@ -12,7 +13,8 @@
         Width="420" Height="320"
         MinWidth="280" MinHeight="200"
         CanResize="True"
-        ShowInTaskbar="False">
+        ShowInTaskbar="False"
+        Title="{Binding Title}">
 
   <Window.Styles>
     <Style Selector="Button.title-bar-btn">
@@ -52,58 +54,60 @@
     </Style>
   </Window.Styles>
 
-  <Panel>
-    <!-- Content area with top padding for title bar -->
-    <ContentPresenter x:Name="PanelContent"
-                      Margin="0,32,0,0"/>
+  <Window.Content>
+    <Panel>
+      <!-- Content area with top padding for title bar -->
+      <ContentPresenter Content="{Binding PanelBody, RelativeSource={RelativeSource AncestorType=panels:BasePanelWindow}}"
+                    Margin="0,32,0,0"/>
 
-    <!-- Title bar overlay — always on top -->
-    <Grid Height="32"
-          VerticalAlignment="Top"
-          Background="{StaticResource TitleBarBackgroundBrush}"
-          PointerPressed="TitleBar_PointerPressed"
-          ColumnDefinitions="*,Auto">
+      <!-- Title bar overlay — always on top -->
+      <Grid Height="32"
+            VerticalAlignment="Top"
+            Background="{StaticResource TitleBarBackgroundBrush}"
+            PointerPressed="TitleBar_PointerPressed"
+            ColumnDefinitions="*,Auto">
 
-      <Border Grid.ColumnSpan="2"
-              BorderBrush="{StaticResource TitleBarBorderBrush}"
-              BorderThickness="0,0,0,1"
-              VerticalAlignment="Bottom"
-              Height="1"/>
+        <Border Grid.ColumnSpan="2"
+                BorderBrush="{StaticResource TitleBarBorderBrush}"
+                BorderThickness="0,0,0,1"
+                VerticalAlignment="Bottom"
+                Height="1"/>
 
-      <TextBlock Grid.Column="0"
-                 Text="{Binding Title}"
-                 Foreground="#000000"
-                 FontFamily="Arial"
-                 FontSize="12"
-                 FontWeight="Bold"
-                 HorizontalAlignment="Center"
-                 VerticalAlignment="Center"
-                 IsHitTestVisible="False"/>
+        <TextBlock Grid.Column="0"
+                   Text="{Binding Title}"
+                   Foreground="#000000"
+                   FontFamily="Arial"
+                   FontSize="12"
+                   FontWeight="Bold"
+                   HorizontalAlignment="Center"
+                   VerticalAlignment="Center"
+                   IsHitTestVisible="False"/>
 
-      <StackPanel Grid.Column="1"
-                  Orientation="Horizontal"
-                  Spacing="2"
-                  Margin="0,0,4,0"
-                  VerticalAlignment="Center">
+        <StackPanel Grid.Column="1"
+                    Orientation="Horizontal"
+                    Spacing="2"
+                    Margin="0,0,4,0"
+                    VerticalAlignment="Center">
 
-        <Button Classes="title-bar-btn"
-                Classes.pinned="{Binding IsPinned}"
-                Command="{Binding TogglePinCommand}"
-                ToolTip.Tip="Pin — keep on top">
-          <TextBlock FontSize="13"
-                     Text="{Binding IsPinned,
-                            Converter={x:Static local:PinIconConverter.Instance}}"/>
-        </Button>
+          <Button Classes="title-bar-btn"
+                  Classes.pinned="{Binding IsPinned}"
+                  Command="{Binding TogglePinCommand}"
+                  ToolTip.Tip="Pin — keep on top">
+            <TextBlock FontSize="13"
+                       Text="{Binding IsPinned,
+                              Converter={x:Static local:PinIconConverter.Instance}}"/>
+          </Button>
 
-        <Button Classes="title-bar-btn"
-                Click="CloseButton_Click"
-                ToolTip.Tip="Close">
-          <TextBlock Text="✕"
-                     Foreground="#000000"
-                     FontSize="12"/>
-        </Button>
+          <Button Classes="title-bar-btn"
+                  Click="CloseButton_Click"
+                  ToolTip.Tip="Close">
+            <TextBlock Text="✕"
+                       Foreground="#000000"
+                       FontSize="12"/>
+          </Button>
 
-      </StackPanel>
-    </Grid>
-  </Panel>
+        </StackPanel>
+      </Grid>
+    </Panel>
+  </Window.Content>
 </Window>

--- a/Views/Panels/BasePanelWindow.axaml.cs
+++ b/Views/Panels/BasePanelWindow.axaml.cs
@@ -1,5 +1,7 @@
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Input;
+using Avalonia.Metadata;
 using System;
 using vTFMS.ViewModels.Panels;
 
@@ -7,40 +9,35 @@ namespace vTFMS.Views.Panels;
 
 public partial class BasePanelWindow : Window
 {
+    /// <summary>
+    /// Child AXAML content routes here instead of replacing Window.Content,
+    /// so the custom title bar grid stays intact.
+    /// </summary>
+    public static readonly StyledProperty<object?> PanelBodyProperty =
+        AvaloniaProperty.Register<BasePanelWindow, object?>(nameof(PanelBody));
+
+    [Content]
+    public object? PanelBody
+    {
+        get => GetValue(PanelBodyProperty);
+        set => SetValue(PanelBodyProperty, value);
+    }
+
     public BasePanelWindow()
     {
         InitializeComponent();
     }
 
-    public new object? Content
-    {
-        get => PanelContent?.Content;
-        set
-        {
-            // Don't intercept if it's the base Panel being set internally
-            if (value is Panel)
-            {
-                base.Content = value;
-                return;
-            }
-            if (PanelContent != null)
-                PanelContent.Content = value;
-            else
-                Initialized += (_, _) =>
-                {
-                    if (PanelContent != null)
-                        PanelContent.Content = value;
-                };
-        }
-    }
-
     protected override void OnDataContextChanged(EventArgs e)
     {
         base.OnDataContextChanged(e);
+
         if (DataContext is BasePanelViewModel vm)
         {
             vm.PinStateChanged += (_, isPinned) =>
+            {
                 Topmost = isPinned;
+            };
             Topmost = vm.IsPinned;
         }
     }

--- a/Views/Panels/ColorPickerWindow.axaml.cs
+++ b/Views/Panels/ColorPickerWindow.axaml.cs
@@ -158,6 +158,6 @@ public partial class ColorPickerWindow : BasePanelWindow
         mainStack.Children.Add(colorView);
         mainStack.Children.Add(buttonRow);
 
-        PanelContent.Content = mainStack;
+        PanelBody = mainStack;
     }
 }

--- a/Views/Panels/FlightCountPanelWindow.axaml.cs
+++ b/Views/Panels/FlightCountPanelWindow.axaml.cs
@@ -86,7 +86,7 @@ public partial class FlightCountPanelWindow : BasePanelWindow
             Avalonia.Threading.Dispatcher.UIThread.Post(RebuildStack);
 
         scroll.Content = stack;
-        PanelContent.Content = scroll;
+        PanelBody = scroll;
     }
 
     private static Control BuildRow(string arr, string dep,

--- a/Views/Panels/OverlaysPanelWindow.axaml.cs
+++ b/Views/Panels/OverlaysPanelWindow.axaml.cs
@@ -49,6 +49,6 @@ public partial class OverlaysPanelWindow : BasePanelWindow
             Margin = new Avalonia.Thickness(4)
         };
         stack.Children.Add(artccCheck);
-        PanelContent.Content = stack;
+        PanelBody = stack;
     }
 }


### PR DESCRIPTION
Child AXAML content was replacing Window.Content, overwriting the BasePanelWindow title bar layout. Added a [Content]-attributed PanelBody styled property so child content routes to the correct slot. Explicitly set Window.Content in BasePanelWindow.axaml to prevent the base layout from being redirected.

Updated OverlaysPanelWindow, FlightCountPanelWindow, and ColorPickerWindow to use PanelBody instead of PanelContent.Content.

Added the binding title for those systems that add an additional titlebar.

Closes #55 