### PR TITLE
feat: add Enable/Disable VATSIM Data toggle to Flights menu

### DIFF
--- a/App.axaml
+++ b/App.axaml
@@ -20,6 +20,9 @@
             <converters:PinIconConverter x:Key="PinIconConverter"/>
             <converters:HexToBrushConverter x:Key="HexToBrushConverter"/>
             <converters:HexToContrastBrushConverter x:Key="HexToContrastBrushConverter"/>
+            <converters:BoolToCheckConverter x:Key="BoolToCheckConverter"/>
+            <converters:BoolToOpacityConverter x:Key="BoolToOpacityConverter"/>
+            <converters:BoolToVatsimTipConverter x:Key="BoolToVatsimTipConverter"/>
             <Color x:Key="PanelBackground">#ffe4c4</Color>
             <Color x:Key="PanelBorder">#ede9e3</Color>
             <Color x:Key="TitleBarBackground">#e1ddd8</Color>

--- a/Converters/BoolToCheckConverter.cs
+++ b/Converters/BoolToCheckConverter.cs
@@ -1,0 +1,20 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+
+namespace vTFMS.Converters;
+
+public class BoolToCheckConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType,
+        object? parameter, CultureInfo culture)
+    {
+        return value is true ? "✓" : null;
+    }
+
+    public object? ConvertBack(object? value, Type targetType,
+        object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/Converters/VatsimStatusConverters.cs
+++ b/Converters/VatsimStatusConverters.cs
@@ -1,0 +1,35 @@
+using Avalonia.Data.Converters;
+using System;
+using System.Globalization;
+
+namespace vTFMS.Converters;
+
+public class BoolToOpacityConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType,
+        object? parameter, CultureInfo culture)
+    {
+        return value is true ? 1.0 : 0.3;
+    }
+
+    public object ConvertBack(object? value, Type targetType,
+        object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}
+
+public class BoolToVatsimTipConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType,
+        object? parameter, CultureInfo culture)
+    {
+        return value is true ? "VATSIM data active" : "VATSIM data disabled";
+    }
+
+    public object ConvertBack(object? value, Type targetType,
+        object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -115,12 +115,17 @@
 
       <MenuItem Header="Flights" Foreground="{StaticResource ForegroundPrimaryBrush}"
                 FontFamily="Arial" FontSize="13">
-        <MenuItem Header="Select Flights..."
-                  FontFamily="Arial" FontSize="12"
-                  Command="{Binding OpenSelectFlightsCommand}"/>
-        <MenuItem Header="Show/Hide Flight Count"
-                  FontFamily="Arial" FontSize="12"
-                  Command="{Binding ToggleFlightCountCommand}"/>
+          <MenuItem Header="Enable VATSIM Data"
+                    FontFamily="Arial" FontSize="12"
+                    Command="{Binding ToggleVatsimDataCommand}"
+                    Icon="{Binding VatsimDataEnabled,
+                           Converter={StaticResource BoolToCheckConverter}}"/>
+          <MenuItem Header="Select Flights..."
+                    FontFamily="Arial" FontSize="12"
+                    Command="{Binding OpenSelectFlightsCommand}"/>
+          <MenuItem Header="Show/Hide Flight Count"
+                    FontFamily="Arial" FontSize="12"
+                    Command="{Binding ToggleFlightCountCommand}"/>
       </MenuItem>
 
     <MenuItem Header="Alerts" Foreground="{StaticResource ForegroundPrimaryBrush}"
@@ -179,12 +184,14 @@
       <Grid ColumnDefinitions="Auto,*,Auto">
 
         <Image Grid.Column="0"
-               Source="avares://vTFMS/Assets/vatsim-logo.png"
-               Height="20"
-               Margin="0,0,8,0"
-               VerticalAlignment="Center"
-               IsVisible="{Binding VatsimConnected}"
-               ToolTip.Tip="VATSIM data active"/>
+           Source="avares://vTFMS/Assets/vatsim-logo.png"
+           Height="20"
+           Margin="0,0,8,0"
+           VerticalAlignment="Center"
+           Opacity="{Binding VatsimDataEnabled,
+                     Converter={StaticResource BoolToOpacityConverter}}"
+           ToolTip.Tip="{Binding VatsimDataEnabled,
+                         Converter={StaticResource BoolToVatsimTipConverter}}"/>
 
         <TextBlock Grid.Column="1"
            Text="{Binding AppVersion, StringFormat='v{0}'}"

--- a/Services/IVatsimService.cs
+++ b/Services/IVatsimService.cs
@@ -7,6 +7,7 @@ namespace vTFMS.Services;
 public interface IVatsimService
 {
     event EventHandler<List<VatsimPilot>>? PilotsUpdated;
+    bool IsRunning { get; }
     void Start();
     void Stop();
     List<VatsimPilot> CurrentPilots { get; }

--- a/Services/VatsimService.cs
+++ b/Services/VatsimService.cs
@@ -38,9 +38,11 @@ public class VatsimService : IVatsimService, IDisposable
 
     public event EventHandler<List<VatsimPilot>>? PilotsUpdated;
     public List<VatsimPilot> CurrentPilots { get; private set; } = new();
+    public bool IsRunning { get; private set; }
 
     public void Start()
     {
+        IsRunning = true;
         _cts = new CancellationTokenSource();
 
         // Fetch immediately
@@ -57,6 +59,7 @@ public class VatsimService : IVatsimService, IDisposable
 
     public void Stop()
     {
+        IsRunning = false;
         _cts.Cancel();
         _timer?.Dispose();
         _timer = null;

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -46,6 +46,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _flightCountWindow.Show(_mainWindow);
     }
 
+    [RelayCommand]
+    private void ToggleVatsimData()
+    {
+        TsdViewModel.VatsimDataEnabled = !TsdViewModel.VatsimDataEnabled;
+        OnPropertyChanged(nameof(VatsimDataEnabled));
+    }
+
+    public bool VatsimDataEnabled => TsdViewModel.VatsimDataEnabled;
+
     [ObservableProperty]
     private string _currentTime = string.Empty;
 
@@ -81,6 +90,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
         {
             if (e.PropertyName == nameof(TsdViewModel.VatsimConnected))
                 OnPropertyChanged(nameof(VatsimConnected));
+            if (e.PropertyName == nameof(TsdViewModel.VatsimDataEnabled))
+                OnPropertyChanged(nameof(VatsimDataEnabled));
         };
     }
 

--- a/ViewModels/TsdViewModel.cs
+++ b/ViewModels/TsdViewModel.cs
@@ -73,6 +73,29 @@ public partial class TsdViewModel : ObservableObject, IDisposable
     [ObservableProperty]
     private bool _vatsimConnected = false;
 
+    private bool _vatsimDataEnabled;
+    public bool VatsimDataEnabled
+    {
+        get => _vatsimDataEnabled;
+        set
+        {
+            if (SetProperty(ref _vatsimDataEnabled, value))
+            {
+                if (value)
+                {
+                    _vatsimService.Start();
+                }
+                else
+                {
+                    _vatsimService.Stop();
+                    VatsimConnected = false;
+                    Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+                        VisiblePilots.Clear());
+                }
+            }
+        }
+    }
+
     [ObservableProperty]
     private bool _showArtcc = false;
 
@@ -179,7 +202,6 @@ public partial class TsdViewModel : ObservableObject, IDisposable
         SelectFlightsViewModel = new SelectFlightsPanelViewModel(this);
 
         _vatsimService.PilotsUpdated += OnPilotsUpdated;
-        _vatsimService.Start();
 
         _weatherService.AutoRefreshTriggered += OnAutoRefreshTriggered;
 


### PR DESCRIPTION
## Summary

VATSIM data is no longer fetched automatically on startup. Users must explicitly enable it via **Flights → Enable VATSIM Data**, improving resource management for sessions where only map overlays (TRACON boundaries, fixes, etc.) are needed.

## Changes

**New files:**
- `Converters/BoolToCheckConverter.cs` — renders a ✓ in the menu when VATSIM data is enabled
- `Converters/VatsimStatusConverters.cs` — `BoolToOpacityConverter` (dims logo when disabled) and `BoolToVatsimTipConverter` (dynamic tooltip text)

**Service layer:**
- `IVatsimService` — added `IsRunning` property to the interface
- `VatsimService` — implemented `IsRunning`, set in `Start()`/`Stop()`

**ViewModel layer:**
- `TsdViewModel` — removed auto-start `_vatsimService.Start()` from constructor; added `VatsimDataEnabled` property that starts/stops the service and clears pilots on disable
- `MainViewModel` — added `ToggleVatsimData` relay command and `VatsimDataEnabled` property forwarding

**UI layer:**
- `MainWindow.axaml` — added "Enable VATSIM Data" menu item with check mark at the top of the Flights menu; status bar VATSIM logo is now always visible with opacity reflecting enabled/disabled state
- `App.axaml` — registered three new converters

## Behavior

- On startup: no VATSIM polling, logo dimmed at 30% opacity, tooltip reads "VATSIM data disabled"
- Toggle on: service starts polling, logo goes full opacity, tooltip reads "VATSIM data active"
- Toggle off: service stops, visible pilots cleared, connection indicator reset, logo dims back