### PR TITLE
fix: streamline color picker and adapt panel UX

### DIFF
--- a/ViewModels/Panels/AdaptPanelViewModel.cs
+++ b/ViewModels/Panels/AdaptPanelViewModel.cs
@@ -9,7 +9,7 @@ namespace vTFMS.ViewModels.Panels;
 public partial class AdaptPanelViewModel : BasePanelViewModel
 {
     private readonly TsdViewModel _tsdViewModel;
-    private DisplaySettings _original = new();
+    private readonly DisplaySettings _original;
 
     [ObservableProperty] private string _backgroundColor = string.Empty;
     [ObservableProperty] private string _boundaryColor = string.Empty;
@@ -28,13 +28,33 @@ public partial class AdaptPanelViewModel : BasePanelViewModel
     [ObservableProperty] private string _dataBlockColor = string.Empty;
     [ObservableProperty] private string _mapLabelColor = string.Empty;
 
+    // Prevents live-push during initial LoadFromSettings
+    private bool _isLoading;
+
     public AdaptPanelViewModel(TsdViewModel tsdViewModel)
     {
         Title = "Customize Colors and Fonts";
         _tsdViewModel = tsdViewModel;
 
-        LoadFromSettings(_tsdViewModel.DisplaySettings);
         _original = _tsdViewModel.DisplaySettings.Clone();
+
+        _isLoading = true;
+        LoadFromSettings(_tsdViewModel.DisplaySettings);
+        _isLoading = false;
+    }
+
+    protected override void OnPropertyChanged(
+        System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        base.OnPropertyChanged(e);
+
+        // Skip during initial load and for non-setting properties
+        if (_isLoading || e.PropertyName == nameof(Title))
+            return;
+
+        // Live-push every color/font change to the TSD
+        _tsdViewModel.DisplaySettings = ToSettings();
+        _tsdViewModel.ApplyDisplaySettings();
     }
 
     private void LoadFromSettings(DisplaySettings s)
@@ -78,32 +98,21 @@ public partial class AdaptPanelViewModel : BasePanelViewModel
     };
 
     [RelayCommand]
-    private void Apply()
-    {
-        _tsdViewModel.DisplaySettings = ToSettings();
-        _tsdViewModel.ApplyDisplaySettings();
-    }
-
-    [RelayCommand]
     private void Ok()
     {
-        Apply();
         OkRequested?.Invoke(this, EventArgs.Empty);
     }
 
     [RelayCommand]
     private void Cancel()
     {
+        _isLoading = true;
         LoadFromSettings(_original);
+        _isLoading = false;
+
         _tsdViewModel.DisplaySettings = _original.Clone();
         _tsdViewModel.ApplyDisplaySettings();
         OkRequested?.Invoke(this, EventArgs.Empty);
-    }
-
-    [RelayCommand]
-    private void Undo()
-    {
-        LoadFromSettings(_original);
     }
 
     public event EventHandler? OkRequested;

--- a/Views/Panels/AdaptPanelWindow.axaml
+++ b/Views/Panels/AdaptPanelWindow.axaml
@@ -239,12 +239,6 @@
       <Button Content="OK" Command="{Binding OkCommand}"
               FontFamily="Arial" FontSize="11"
               MinWidth="60" Margin="4"/>
-      <Button Content="Apply" Command="{Binding ApplyCommand}"
-              FontFamily="Arial" FontSize="11"
-              MinWidth="60" Margin="4"/>
-      <Button Content="Undo" Command="{Binding UndoCommand}"
-              FontFamily="Arial" FontSize="11"
-              MinWidth="60" Margin="4"/>
       <Button Content="Cancel" Command="{Binding CancelCommand}"
               FontFamily="Arial" FontSize="11"
               MinWidth="60" Margin="4"/>

--- a/Views/Panels/ColorPickerWindow.axaml.cs
+++ b/Views/Panels/ColorPickerWindow.axaml.cs
@@ -40,18 +40,18 @@ public partial class ColorPickerWindow : BasePanelWindow
 
         var presets = new List<(string Name, string Hex)>
         {
-            ("Black",   "#000000"),
-            ("Blue",    "#0000FF"),
-            ("Orange",  "#FF8C00"),
             ("Red",     "#FF0000"),
-            ("Green",   "#008000"),
-            ("Gray",    "#808080"),
+            ("Orange",  "#FF8C00"),
             ("Yellow",  "#FFFF00"),
+            ("Lime",    "#00FF00"),
+            ("Green",   "#008000"),
             ("Cyan",    "#00CCFF"),
-            ("White",   "#FFFFFF"),
+            ("Blue",    "#0000FF"),
             ("Purple",  "#800080"),
             ("Magenta", "#FF00FF"),
-            ("Lime",    "#00FF00"),
+            ("White",   "#FFFFFF"),
+            ("Gray",    "#808080"),
+            ("Black",   "#000000"),
         };
 
         var presetWrap = new WrapPanel
@@ -86,7 +86,10 @@ public partial class ColorPickerWindow : BasePanelWindow
             ToolTip.SetTip(swatch, name);
 
             swatch.PointerPressed += (_, _) =>
-                colorView.Color = Avalonia.Media.Color.Parse(hex);
+            {
+                ColorSelected?.Invoke(this, hex);
+                Close();
+            };
 
             swatch.PointerEntered += (_, _) =>
                 swatch.BorderBrush = new SolidColorBrush(
@@ -96,15 +99,6 @@ public partial class ColorPickerWindow : BasePanelWindow
 
             presetWrap.Children.Add(swatch);
         }
-
-        var applyBtn = new Button
-        {
-            Content = "Apply",
-            FontFamily = new FontFamily("Arial"),
-            FontSize = 11,
-            MinWidth = 70,
-            Margin = new Avalonia.Thickness(4)
-        };
 
         var okBtn = new Button
         {
@@ -124,14 +118,6 @@ public partial class ColorPickerWindow : BasePanelWindow
             Margin = new Avalonia.Thickness(4)
         };
 
-        applyBtn.Click += (_, _) =>
-        {
-            var selected = $"#{colorView.Color.R:X2}" +
-                           $"{colorView.Color.G:X2}" +
-                           $"{colorView.Color.B:X2}";
-            ColorSelected?.Invoke(this, selected);
-        };
-
         okBtn.Click += (_, _) =>
         {
             var selected = $"#{colorView.Color.R:X2}" +
@@ -149,7 +135,7 @@ public partial class ColorPickerWindow : BasePanelWindow
             HorizontalAlignment = HorizontalAlignment.Center,
             Margin = new Avalonia.Thickness(8)
         };
-        buttonRow.Children.Add(applyBtn);
+
         buttonRow.Children.Add(okBtn);
         buttonRow.Children.Add(cancelBtn);
 


### PR DESCRIPTION
## Summary

Overhauls the color picking experience across the application. Preset colors now apply instantly and close the picker. The Adapt panel now live-previews color changes on the radar, with Cancel reverting to the original state.

## Changes

**`ColorPickerWindow.axaml.cs`**
- Removed Apply button — only OK and Cancel remain
- Clicking a preset swatch now fires `ColorSelected` and closes the picker immediately (previously it just set the picker graph color)
- Reordered presets: warm → cool → neutrals for a more logical grouping

**`AdaptPanelViewModel.cs`**
- Colors now live-preview on the radar via `OnPropertyChanged` override — every color change immediately pushes to the TSD
- Added `_isLoading` guard to prevent redundant applies during initial load and cancel revert
- Removed Apply and Undo commands (no longer needed)
- OK simply closes the panel (colors are already live)
- Cancel reverts all colors to the snapshot taken when the panel was opened

**`AdaptPanelWindow.axaml`**
- Removed Apply and Undo buttons from the bottom button row

## UX Flow

**Color picker:**
- Click preset → color applies, picker closes
- Use color graph + click OK → color applies, picker closes
- Click Cancel → nothing changes, picker closes

**Adapt panel:**
- Open panel → change any color → radar updates immediately
- Click OK → close panel, keep current colors
- Click Cancel → revert all colors to how they were when panel opened, close panel

## Note

The Select Flights panel retains its Apply button as the filter workflow benefits from explicit application.