### PR TITLE
feat: add remove row button to flight filters panel

### DIFF
--- a/ViewModels/Panels/SelectFlightsPanelViewModel.cs
+++ b/ViewModels/Panels/SelectFlightsPanelViewModel.cs
@@ -35,6 +35,15 @@ public partial class SelectFlightsPanelViewModel : BasePanelViewModel
     }
 
     [RelayCommand]
+    private void RemoveRow(FlightFilter filter)
+    {
+        Filters.Remove(filter);
+        // Renumber remaining rows
+        for (int i = 0; i < Filters.Count; i++)
+            Filters[i].RowNumber = i + 1;
+    }
+
+    [RelayCommand]
     private void Apply()
     {
         _tsdViewModel.SetFlightFilters(Filters.ToList());

--- a/Views/Panels/SelectFlightsPanelWindow.axaml
+++ b/Views/Panels/SelectFlightsPanelWindow.axaml
@@ -12,8 +12,8 @@
 
     <!-- Column headers -->
     <Grid Grid.Row="0"
-          ColumnDefinitions="30,50,60,80,80,70,60,70,70"
-          Margin="4,4,4,0">
+        ColumnDefinitions="30,50,60,80,80,70,60,70,70,30"
+        Margin="4,4,4,0">
       <TextBlock Grid.Column="0" Text=""
                  FontFamily="Arial" FontSize="11" FontWeight="Bold"
                  HorizontalAlignment="Center" VerticalAlignment="Center"/>
@@ -48,7 +48,7 @@
       <ItemsControl ItemsSource="{Binding Filters}">
         <ItemsControl.ItemTemplate>
           <DataTemplate x:DataType="models:FlightFilter">
-            <Grid ColumnDefinitions="30,50,60,80,80,70,60,70,70"
+            <Grid ColumnDefinitions="30,50,60,80,80,70,60,70,70,30"
                   Margin="4,2,4,2">
 
               <TextBlock Grid.Column="0"
@@ -100,6 +100,14 @@
                         IsChecked="{Binding Filter}"
                         HorizontalAlignment="Center"/>
 
+              <Button Grid.Column="9"
+                      Content="✕"
+                      FontFamily="Arial" FontSize="9"
+                      Padding="4,1"
+                      HorizontalAlignment="Center"
+                      VerticalAlignment="Center"
+                      Command="{Binding $parent[ItemsControl].((vm:SelectFlightsPanelViewModel)DataContext).RemoveRowCommand}"
+                      CommandParameter="{Binding}"/>
             </Grid>
           </DataTemplate>
         </ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary

Adds the ability to remove individual flight filter rows from the Select Flights panel. Each row now has a small "✕" button on the right side that removes it and renumbers the remaining rows.

## Changes

**`SelectFlightsPanelViewModel.cs`**
- Added `RemoveRow(FlightFilter)` relay command that removes the specified filter and renumbers remaining rows sequentially

**`SelectFlightsPanelWindow.axaml`**
- Added a 10th column (`30` wide) to both the header grid and the `DataTemplate` row grid
- Added a "✕" button in each row that binds to `RemoveRowCommand` on the ViewModel via `$parent[ItemsControl]` traversal, passing the current `FlightFilter` as `CommandParameter`