### PR TITLE
feat: add font customization to Adapt panel (closes #54)

### DIFF
--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -26,6 +26,7 @@ public partial class App : Application
             IVatsimService vatsimService = new VatsimService();
             IProfileService profileService = new ProfileService();
             IWeatherService weatherService = new WeatherService();
+            IFontService fontService = new FontService();
     
             desktop.MainWindow = new MainWindow();
     
@@ -34,7 +35,7 @@ public partial class App : Application
     
             var mainViewModel = new MainViewModel(panelManager, mapDataService,
                 vatsimService, profileService, weatherService,
-                desktop.MainWindow);
+                fontService, desktop.MainWindow);
     
             desktop.MainWindow.DataContext = mainViewModel;
             desktop.Exit += (_, _) => mainViewModel.Dispose();

--- a/Services/FontService.cs
+++ b/Services/FontService.cs
@@ -1,0 +1,63 @@
+using Avalonia.Media;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace vTFMS.Services;
+
+public class FontService : IFontService
+{
+    public List<string> GetMonospaceFonts()
+    {
+        // Symbol/dingbat fonts that pass monospace detection
+        var excludedFonts = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+        {
+            "Marlett", "Wingdings", "Wingdings 2", "Wingdings 3",
+            "Symbol", "Webdings", "MT Extra", "HoloLens MDL2 Assets",
+            "Segoe MDL2 Assets", "Segoe Fluent Icons"
+        };
+    
+        var mono = new List<string>();
+    
+        foreach (var family in FontManager.Current.SystemFonts)
+        {
+            try
+            {
+                if (excludedFonts.Contains(family.Name))
+                    continue;
+    
+                if (IsMonospace(family))
+                    mono.Add(family.Name);
+            }
+            catch
+            {
+                System.Diagnostics.Debug.WriteLine(
+                    $"FontService: skipping {family.Name}");
+            }
+        }
+    
+        if (!mono.Contains("Courier New"))
+            mono.Add("Courier New");
+    
+        mono.Sort(StringComparer.OrdinalIgnoreCase);
+        return mono;
+    }
+
+    private static bool IsMonospace(FontFamily family)
+    {
+        var typeface = new Typeface(family);
+
+        var narrowChar = new FormattedText(
+            "i", CultureInfo.InvariantCulture,
+            FlowDirection.LeftToRight, typeface,
+            12, Brushes.Black);
+
+        var wideChar = new FormattedText(
+            "W", CultureInfo.InvariantCulture,
+            FlowDirection.LeftToRight, typeface,
+            12, Brushes.Black);
+
+        return Math.Abs(narrowChar.Width - wideChar.Width) < 0.01;
+    }
+}

--- a/Services/IFontService.cs
+++ b/Services/IFontService.cs
@@ -1,0 +1,8 @@
+using System.Collections.Generic;
+
+namespace vTFMS.Services;
+
+public interface IFontService
+{
+    List<string> GetMonospaceFonts();
+}

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -21,6 +21,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly IProfileService _profileService;
     private readonly IWeatherService _weatherService;
     private readonly IMapDataService _mapDataService;
+    private readonly IFontService _fontService;
     private readonly Window _mainWindow;
 
 
@@ -72,11 +73,13 @@ public partial class MainViewModel : ObservableObject, IDisposable
                          IVatsimService vatsimService,
                          IProfileService profileService,
                          IWeatherService weatherService,
+                         IFontService fontService,
                          Window mainWindow)
     {
         _panelManager = panelManager;
         _profileService = profileService;
         _weatherService = weatherService;
+        _fontService = fontService;
         _mapDataService = mapDataService;
         _mainWindow = mainWindow;
         TsdViewModel = new TsdViewModel(mapDataService, vatsimService, weatherService);
@@ -144,7 +147,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     [RelayCommand]
     private void OpenAdapt() =>
     _panelManager.OpenWithArgs(
-        new AdaptPanelWindow(TsdViewModel));
+        new AdaptPanelWindow(TsdViewModel, _fontService));
 
     [RelayCommand]
     private void OpenNasMonitor() =>

--- a/ViewModels/Panels/AdaptPanelViewModel.cs
+++ b/ViewModels/Panels/AdaptPanelViewModel.cs
@@ -1,7 +1,9 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System;
+using System.Collections.Generic;
 using vTFMS.Models;
+using vTFMS.Services;
 using vTFMS.ViewModels;
 
 namespace vTFMS.ViewModels.Panels;
@@ -28,13 +30,18 @@ public partial class AdaptPanelViewModel : BasePanelViewModel
     [ObservableProperty] private string _dataBlockColor = string.Empty;
     [ObservableProperty] private string _mapLabelColor = string.Empty;
 
+    public List<string> AvailableFonts { get; }
+    public List<double> AvailableSizes { get; } = new() { 8, 9, 10, 11, 12, 14 };
+
     // Prevents live-push during initial LoadFromSettings
     private bool _isLoading;
 
-    public AdaptPanelViewModel(TsdViewModel tsdViewModel)
+    public AdaptPanelViewModel(TsdViewModel tsdViewModel, IFontService fontService)
     {
         Title = "Customize Colors and Fonts";
         _tsdViewModel = tsdViewModel;
+
+        AvailableFonts = fontService.GetMonospaceFonts();
 
         _original = _tsdViewModel.DisplaySettings.Clone();
 

--- a/Views/Panels/AdaptPanelWindow.axaml
+++ b/Views/Panels/AdaptPanelWindow.axaml
@@ -5,9 +5,25 @@
     xmlns:vm="using:vTFMS.ViewModels.Panels"
     x:Class="vTFMS.Views.Panels.AdaptPanelWindow"
     x:DataType="vm:AdaptPanelViewModel"
-    Width="680" Height="420">
+    Width="680" Height="420"
+    RequestedThemeVariant="Light">
 
   <StackPanel Margin="4">
+
+    <!-- Force ComboBox dropdowns to be readable -->
+    <StackPanel.Styles>
+      <Style Selector="ComboBox /template/ Popup Border">
+        <Setter Property="Background" Value="{StaticResource PanelBackgroundBrush}"/>
+      </Style>
+      <Style Selector="ComboBoxItem">
+        <Setter Property="Foreground" Value="Black"/>
+        <Setter Property="FontFamily" Value="Arial"/>
+        <Setter Property="FontSize" Value="11"/>
+      </Style>
+      <Style Selector="ComboBoxItem:pointerover /template/ ContentPresenter">
+        <Setter Property="Background" Value="#edcfaa"/>
+      </Style>
+    </StackPanel.Styles>
 
     <!-- Color grid: 4 rows × 3 columns -->
     <Grid ColumnDefinitions="*,*,*"
@@ -16,7 +32,8 @@
 
       <!-- Row 0 -->
       <StackPanel Grid.Row="0" Grid.Column="0"
-                  Orientation="Horizontal" Margin="4,3">
+                  Orientation="Horizontal" Margin="4,3"
+                  HorizontalAlignment="Center">
         <Border Width="120" Height="22" CornerRadius="2"
                 Background="{Binding BackgroundColor,
                   Converter={StaticResource HexToBrushConverter}}"
@@ -33,7 +50,8 @@
       </StackPanel>
 
       <StackPanel Grid.Row="0" Grid.Column="1"
-                  Orientation="Horizontal" Margin="4,3">
+                  Orientation="Horizontal" Margin="4,3"
+                  HorizontalAlignment="Center">
         <Border Width="120" Height="22" CornerRadius="2"
                 Background="{Binding BoundaryColor,
                   Converter={StaticResource HexToBrushConverter}}"
@@ -50,7 +68,8 @@
       </StackPanel>
 
       <StackPanel Grid.Row="0" Grid.Column="2"
-                  Orientation="Horizontal" Margin="4,3">
+                  Orientation="Horizontal" Margin="4,3"
+                  HorizontalAlignment="Center">
         <Border Width="120" Height="22" CornerRadius="2"
                 Background="{Binding TraconColor,
                   Converter={StaticResource HexToBrushConverter}}"
@@ -68,7 +87,8 @@
 
       <!-- Row 1 -->
       <StackPanel Grid.Row="1" Grid.Column="0"
-                  Orientation="Horizontal" Margin="4,3">
+                  Orientation="Horizontal" Margin="4,3"
+                  HorizontalAlignment="Center">
         <Border Width="120" Height="22" CornerRadius="2"
                 Background="{Binding ArtccColor,
                   Converter={StaticResource HexToBrushConverter}}"
@@ -85,7 +105,8 @@
       </StackPanel>
 
       <StackPanel Grid.Row="1" Grid.Column="1"
-                  Orientation="Horizontal" Margin="4,3">
+                  Orientation="Horizontal" Margin="4,3"
+                  HorizontalAlignment="Center">
         <Border Width="120" Height="22" CornerRadius="2"
                 Background="{Binding AirportColor,
                   Converter={StaticResource HexToBrushConverter}}"
@@ -102,7 +123,8 @@
       </StackPanel>
 
       <StackPanel Grid.Row="1" Grid.Column="2"
-                  Orientation="Horizontal" Margin="4,3">
+                  Orientation="Horizontal" Margin="4,3"
+                  HorizontalAlignment="Center">
         <Border Width="120" Height="22" CornerRadius="2"
                 Background="{Binding VorColor,
                   Converter={StaticResource HexToBrushConverter}}"
@@ -120,7 +142,8 @@
 
       <!-- Row 2 -->
       <StackPanel Grid.Row="2" Grid.Column="0"
-                  Orientation="Horizontal" Margin="4,3">
+                  Orientation="Horizontal" Margin="4,3"
+                  HorizontalAlignment="Center">
         <Border Width="120" Height="22" CornerRadius="2"
                 Background="{Binding NdbColor,
                   Converter={StaticResource HexToBrushConverter}}"
@@ -137,7 +160,8 @@
       </StackPanel>
 
       <StackPanel Grid.Row="2" Grid.Column="1"
-                  Orientation="Horizontal" Margin="4,3">
+                  Orientation="Horizontal" Margin="4,3"
+                  HorizontalAlignment="Center">
         <Border Width="120" Height="22" CornerRadius="2"
                 Background="{Binding FixColor,
                   Converter={StaticResource HexToBrushConverter}}"
@@ -154,7 +178,8 @@
       </StackPanel>
 
       <StackPanel Grid.Row="2" Grid.Column="2"
-                  Orientation="Horizontal" Margin="4,3">
+                  Orientation="Horizontal" Margin="4,3"
+                  HorizontalAlignment="Center">
         <Border Width="120" Height="22" CornerRadius="2"
                 Background="{Binding JetRoutesColor,
                   Converter={StaticResource HexToBrushConverter}}"
@@ -172,7 +197,8 @@
 
       <!-- Row 3 -->
       <StackPanel Grid.Row="3" Grid.Column="0"
-                  Orientation="Horizontal" Margin="4,3">
+                  Orientation="Horizontal" Margin="4,3"
+                  HorizontalAlignment="Center">
         <Border Width="120" Height="22" CornerRadius="2"
                 Background="{Binding VictorRoutesColor,
                   Converter={StaticResource HexToBrushConverter}}"
@@ -189,7 +215,8 @@
       </StackPanel>
 
       <StackPanel Grid.Row="3" Grid.Column="1"
-                  Orientation="Horizontal" Margin="4,3">
+                  Margin="4,3"
+                  HorizontalAlignment="Center">
         <Border Width="120" Height="22" CornerRadius="2"
                 Background="{Binding DataBlockColor,
                   Converter={StaticResource HexToBrushConverter}}"
@@ -203,14 +230,26 @@
                      Foreground="{Binding DataBlockColor,
                        Converter={StaticResource HexToContrastBrushConverter}}"/>
         </Border>
-        <Button Content="Helv-10"
-                FontFamily="Arial" FontSize="10"
-                Padding="4,2" Margin="4,0,0,0"
-                VerticalAlignment="Center"/>
+        <StackPanel Orientation="Horizontal" Margin="0,4,0,0"
+                    HorizontalAlignment="Center">
+          <ComboBox ItemsSource="{Binding AvailableFonts}"
+                    SelectedItem="{Binding DataBlockFont}"
+                    FontFamily="Arial" FontSize="10"
+                    Foreground="Black"
+                    Width="120" Height="24"
+                    Padding="4,2"/>
+          <ComboBox ItemsSource="{Binding AvailableSizes}"
+                    SelectedItem="{Binding DataBlockFontSize}"
+                    FontFamily="Arial" FontSize="10"
+                    Foreground="Black"
+                    Width="65" Height="24"
+                    Padding="4,2" Margin="4,0,0,0"/>
+        </StackPanel>
       </StackPanel>
 
       <StackPanel Grid.Row="3" Grid.Column="2"
-                  Orientation="Horizontal" Margin="4,3">
+                  Margin="4,3"
+                  HorizontalAlignment="Center">
         <Border Width="120" Height="22" CornerRadius="2"
                 Background="{Binding MapLabelColor,
                   Converter={StaticResource HexToBrushConverter}}"
@@ -224,10 +263,21 @@
                      Foreground="{Binding MapLabelColor,
                        Converter={StaticResource HexToContrastBrushConverter}}"/>
         </Border>
-        <Button Content="Helv-10"
-                FontFamily="Arial" FontSize="10"
-                Padding="4,2" Margin="4,0,0,0"
-                VerticalAlignment="Center"/>
+        <StackPanel Orientation="Horizontal" Margin="0,4,0,0"
+                    HorizontalAlignment="Center">
+          <ComboBox ItemsSource="{Binding AvailableFonts}"
+                    SelectedItem="{Binding MapLabelFont}"
+                    FontFamily="Arial" FontSize="10"
+                    Foreground="Black"
+                    Width="120" Height="24"
+                    Padding="4,2"/>
+          <ComboBox ItemsSource="{Binding AvailableSizes}"
+                    SelectedItem="{Binding MapLabelFontSize}"
+                    FontFamily="Arial" FontSize="10"
+                    Foreground="Black"
+                    Width="65" Height="24"
+                    Padding="4,2" Margin="4,0,0,0"/>
+        </StackPanel>
       </StackPanel>
 
     </Grid>

--- a/Views/Panels/AdaptPanelWindow.axaml.cs
+++ b/Views/Panels/AdaptPanelWindow.axaml.cs
@@ -2,6 +2,7 @@ using Avalonia.Controls;
 using Avalonia.Input;
 using System;
 using vTFMS.ViewModels;
+using vTFMS.Services;
 using vTFMS.ViewModels.Panels;
 
 namespace vTFMS.Views.Panels;
@@ -14,9 +15,9 @@ public partial class AdaptPanelWindow : BasePanelWindow
             "Use the constructor that takes a TsdViewModel.");
     }
 
-    public AdaptPanelWindow(TsdViewModel tsdViewModel)
+    public AdaptPanelWindow(TsdViewModel tsdViewModel, IFontService fontService)
     {
-        var vm = new AdaptPanelViewModel(tsdViewModel);
+        var vm = new AdaptPanelViewModel(tsdViewModel, fontService);
         vm.OkRequested += (_, _) => Close();
         DataContext = vm;
         InitializeComponent();


### PR DESCRIPTION
## Summary

Implements font customization in the Adapt panel, allowing users to change the font family and size for Flight DataBlocks and Map Labels. Only system-installed monospace fonts are shown. Closes #54.

## Changes

**New files:**
- `Services/IFontService.cs` — interface with `GetMonospaceFonts()` method
- `Services/FontService.cs` — enumerates system fonts, measures character widths to detect monospace fonts, filters out known symbol/dingbat fonts (Marlett, Wingdings, etc.)

**Modified files:**
- `AdaptPanelViewModel.cs` — accepts `IFontService`, exposes `AvailableFonts` (monospace font names) and `AvailableSizes` (8, 9, 10, 11, 12, 14) for ComboBox binding
- `AdaptPanelWindow.axaml` — replaced static "Helv-10" buttons with font family and size ComboBox dropdowns under Flight DataBlock and Map Labels; added `RequestedThemeVariant="Light"` to window for readable dropdown popups; centered all color swatches in their columns
- `AdaptPanelWindow.axaml.cs` — updated constructor to accept and pass through `IFontService`
- `MainViewModel.cs` — stores `IFontService` and passes it when opening the Adapt panel
- `App.axaml.cs` — creates `FontService` instance and passes it to `MainViewModel`

## How it works

The `FontService` uses Avalonia's `FormattedText` to measure the width of "i" vs "W" at the same font size. If the widths match, the font is monospace. This works cross-platform (Windows and Linux).

Font and size changes live-preview on the radar immediately via the existing `OnPropertyChanged` override. Cancel reverts to the original fonts.