### PR TITLE
feat: add Display All Aircraft toggle to Flights menu (closes #51)

### DIFF
--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -120,6 +120,11 @@
                     Command="{Binding ToggleVatsimDataCommand}"
                     Icon="{Binding VatsimDataEnabled,
                            Converter={StaticResource BoolToCheckConverter}}"/>
+          <MenuItem Header="Display All Aircraft"
+                    FontFamily="Arial" FontSize="12"
+                    Command="{Binding ToggleShowAllAircraftCommand}"
+                    Icon="{Binding ShowAllAircraft,
+                           Converter={StaticResource BoolToCheckConverter}}"/>
           <MenuItem Header="Select Flights..."
                     FontFamily="Arial" FontSize="12"
                     Command="{Binding OpenSelectFlightsCommand}"/>

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -47,6 +47,15 @@ public partial class MainViewModel : ObservableObject, IDisposable
     }
 
     [RelayCommand]
+    private void ToggleShowAllAircraft()
+    {
+        TsdViewModel.ShowAllAircraft = !TsdViewModel.ShowAllAircraft;
+        OnPropertyChanged(nameof(ShowAllAircraft));
+    }
+
+public bool ShowAllAircraft => TsdViewModel.ShowAllAircraft;
+
+    [RelayCommand]
     private void ToggleVatsimData()
     {
         TsdViewModel.VatsimDataEnabled = !TsdViewModel.VatsimDataEnabled;
@@ -92,6 +101,8 @@ public partial class MainViewModel : ObservableObject, IDisposable
                 OnPropertyChanged(nameof(VatsimConnected));
             if (e.PropertyName == nameof(TsdViewModel.VatsimDataEnabled))
                 OnPropertyChanged(nameof(VatsimDataEnabled));
+            if (e.PropertyName == nameof(TsdViewModel.ShowAllAircraft))
+                OnPropertyChanged(nameof(ShowAllAircraft));
         };
     }
 

--- a/ViewModels/TsdViewModel.cs
+++ b/ViewModels/TsdViewModel.cs
@@ -35,6 +35,14 @@ public partial class TsdViewModel : ObservableObject, IDisposable
     private bool _showAirports = false;
 
     [ObservableProperty]
+    private bool _showAllAircraft = false;
+
+    partial void OnShowAllAircraftChanged(bool value)
+    {
+        RefreshVisiblePilots(_vatsimService.CurrentPilots);
+    }
+
+    [ObservableProperty]
     private bool _showWaypoints = false;
 
     [ObservableProperty]
@@ -452,21 +460,21 @@ public partial class TsdViewModel : ObservableObject, IDisposable
                     (!string.IsNullOrWhiteSpace(f.Arrival) ||
                      !string.IsNullOrWhiteSpace(f.Departure)))
                 .ToList();
-
-            if (!activeFilters.Any())
+    
+            if (!ShowAllAircraft && !activeFilters.Any())
             {
                 Avalonia.Threading.Dispatcher.UIThread.Post(() =>
                     VisiblePilots.Clear());
                 return;
             }
-
+    
             var matched = new List<VatsimPilot>();
-
+    
             foreach (var pilot in pilots)
             {
                 if (!IsInMapView(pilot.Lat, pilot.Lon)) continue;
-
-                bool matches = false;
+    
+                bool matchedFilter = false;
                 foreach (var filter in activeFilters)
                 {
                     bool arrivalMatch =
@@ -476,7 +484,7 @@ public partial class TsdViewModel : ObservableObject, IDisposable
                             .Any(a => pilot.Arrival.Contains(
                                 a.ToUpperInvariant(),
                                 StringComparison.OrdinalIgnoreCase));
-
+    
                     bool departureMatch =
                         string.IsNullOrWhiteSpace(filter.Departure) ||
                         filter.Departure
@@ -484,32 +492,38 @@ public partial class TsdViewModel : ObservableObject, IDisposable
                             .Any(d => pilot.Departure.Contains(
                                 d.ToUpperInvariant(),
                                 StringComparison.OrdinalIgnoreCase));
-
+    
                     if (arrivalMatch && departureMatch)
                     {
-                        matches = true;
+                        matchedFilter = true;
                         pilot.MatchedFilterColor = filter.Color;
                         pilot.MatchedDrawRoute = filter.DrawRoute;
                         pilot.MatchedShowRoute = filter.ShowRoute;
                         break;
                     }
                 }
-
-                if (matches)
+    
+                if (matchedFilter)
                 {
                     if (pilot.MatchedDrawRoute &&
                         pilot.ParsedRoute.Count == 0 &&
                         !string.IsNullOrWhiteSpace(pilot.Route))
                     {
                         pilot.ParsedRoute = _mapDataService.ResolveRoute(
-                            pilot.Departure,
-                            pilot.Route,
-                            pilot.Arrival);
+                            pilot.Departure, pilot.Route, pilot.Arrival);
                     }
                     matched.Add(pilot);
                 }
+                else if (ShowAllAircraft)
+                {
+                    // Unfiltered aircraft get default appearance
+                    pilot.MatchedFilterColor = "#FFFFFF";
+                    pilot.MatchedDrawRoute = false;
+                    pilot.MatchedShowRoute = false;
+                    matched.Add(pilot);
+                }
             }
-
+    
             Avalonia.Threading.Dispatcher.UIThread.Post(() =>
             {
                 VisiblePilots.Clear();
@@ -518,7 +532,6 @@ public partial class TsdViewModel : ObservableObject, IDisposable
             });
         });
     }
-
     private void OnRadarUpdated(object? sender, byte[]? data)
     {
         if (data == null) return;


### PR DESCRIPTION
## Summary

Adds a "Display All Aircraft" toggle to the Flights menu. When enabled, every airborne VATSIM pilot in the current map view is shown on the radar in white. Filter-matched aircraft still render with their configured filter color and route settings, taking priority over the default appearance. Closes #51.

## Changes

**`TsdViewModel.cs`**
- Added `ShowAllAircraft` observable property with `OnShowAllAircraftChanged` partial method that triggers a pilot refresh on toggle
- Modified `RefreshVisiblePilots` — when `ShowAllAircraft` is enabled, pilots that don't match any filter are still added to the visible list with default white color and no route drawing

**`MainViewModel.cs`**
- Added `ToggleShowAllAircraft` relay command and `ShowAllAircraft` read-only property
- Added property change forwarding from `TsdViewModel`

**`MainWindow.axaml`**
- Added "Display All Aircraft" checkable menu item in the Flights menu between "Enable VATSIM Data" and "Select Flights..."

## Behavior

- Off (default): only filter-matched aircraft appear on the radar (existing behavior)
- On: all airborne pilots in the map view appear in white; filter-matched pilots override with their configured color/route settings
- Toggling immediately refreshes the display — no need to re-apply filters