### PR TITLE
Add Velopack installer and auto-updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,19 @@ jobs:
           - rid: win-x64
             os: windows-latest
             artifact: vTFMS-win-x64
+            mainExe: vTFMS.exe
           - rid: linux-x64
             os: ubuntu-latest
             artifact: vTFMS-linux-x64
+            mainExe: vTFMS
           - rid: osx-x64
             os: macos-latest
             artifact: vTFMS-osx-x64
+            mainExe: vTFMS
           - rid: osx-arm64
             os: macos-latest
             artifact: vTFMS-osx-arm64
+            mainExe: vTFMS
 
     runs-on: ${{ matrix.os }}
 
@@ -37,18 +41,24 @@ jobs:
         run: dotnet publish -c Release -r ${{ matrix.rid }} -p:Version=${GITHUB_REF_NAME#v}
         shell: bash
 
-      - name: Zip output
+      - name: Install vpk
+        run: dotnet tool install -g vpk
+
+      - name: Pack with Velopack
         run: |
-          OUTDIR="$(pwd)"
-          cd bin/Release/net10.0/${{ matrix.rid }}/publish
-          7z a -tzip "$OUTDIR/${{ matrix.artifact }}.zip" .
+          vpk pack \
+            --packId vTFMS \
+            --packVersion ${GITHUB_REF_NAME#v} \
+            --packDir bin/Release/net10.0/${{ matrix.rid }}/publish \
+            --mainExe ${{ matrix.mainExe }} \
+            --outputDir releases
         shell: bash
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}.zip
+          path: releases/
 
   release:
     needs: publish
@@ -65,5 +75,6 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: artifacts/**/*.zip
+          files: artifacts/**/*
           generate_release_notes: true
+          prerelease: true   # flip to false when you ship a stable release

--- a/App.axaml.cs
+++ b/App.axaml.cs
@@ -27,6 +27,7 @@ public partial class App : Application
             IProfileService profileService = new ProfileService();
             IWeatherService weatherService = new WeatherService();
             IFontService fontService = new FontService();
+            IUpdateService updateService = new UpdateService();
     
             desktop.MainWindow = new MainWindow();
     
@@ -35,7 +36,7 @@ public partial class App : Application
     
             var mainViewModel = new MainViewModel(panelManager, mapDataService,
                 vatsimService, profileService, weatherService,
-                fontService, desktop.MainWindow);
+                fontService, updateService, desktop.MainWindow);
     
             desktop.MainWindow.DataContext = mainViewModel;
             desktop.Exit += (_, _) => mainViewModel.Dispose();

--- a/Helpers/MessageBoxHelper.cs
+++ b/Helpers/MessageBoxHelper.cs
@@ -1,0 +1,83 @@
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Layout;
+using Avalonia.Media;
+
+namespace vTFMS.Helpers;
+
+public static class MessageBoxHelper
+{
+    public static Task ShowInfoAsync(Window owner, string title, string message)
+        => ShowAsync(owner, title, message, confirm: false);
+
+    public static Task<bool> ShowConfirmAsync(Window owner, string title, string message)
+        => ShowAsync(owner, title, message, confirm: true);
+
+    private static async Task<bool> ShowAsync(
+        Window owner, string title, string message, bool confirm)
+    {
+        var result = false;
+
+        var dialog = new Window
+        {
+            Title = title,
+            Width = 360,
+            SizeToContent = SizeToContent.Height,
+            WindowStartupLocation = WindowStartupLocation.CenterOwner,
+            CanResize = false,
+            Background = new SolidColorBrush(Color.Parse("#1e1e1e")),
+            Foreground = new SolidColorBrush(Color.Parse("#ccffcc")),
+        };
+
+        var text = new TextBlock
+        {
+            Text = message,
+            FontFamily = new FontFamily("Arial"),
+            FontSize = 12,
+            Foreground = new SolidColorBrush(Color.Parse("#ccffcc")),
+            TextWrapping = TextWrapping.Wrap,
+            Margin = new Thickness(16, 16, 16, 12)
+        };
+
+        var okBtn = new Button
+        {
+            Content = confirm ? "Yes" : "OK",
+            FontFamily = new FontFamily("Arial"),
+            FontSize = 11,
+            MinWidth = 70,
+            Margin = new Thickness(4)
+        };
+        okBtn.Click += (_, _) => { result = true; dialog.Close(); };
+
+        var btnRow = new StackPanel
+        {
+            Orientation = Orientation.Horizontal,
+            HorizontalAlignment = HorizontalAlignment.Center,
+            Margin = new Thickness(0, 0, 0, 12)
+        };
+        btnRow.Children.Add(okBtn);
+
+        if (confirm)
+        {
+            var cancelBtn = new Button
+            {
+                Content = "No",
+                FontFamily = new FontFamily("Arial"),
+                FontSize = 11,
+                MinWidth = 70,
+                Margin = new Thickness(4)
+            };
+            cancelBtn.Click += (_, _) => dialog.Close();
+            btnRow.Children.Add(cancelBtn);
+        }
+
+        var stack = new StackPanel();
+        stack.Children.Add(text);
+        stack.Children.Add(btnRow);
+        dialog.Content = stack;
+
+        await dialog.ShowDialog(owner);
+        return result;
+    }
+}

--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -175,6 +175,9 @@
 
       <MenuItem Header="Help" Foreground="{StaticResource ForegroundPrimaryBrush}"
           FontFamily="Arial" FontSize="13">
+        <MenuItem Header="Check for Updates"
+            FontFamily="Arial" FontSize="12"
+            Command="{Binding CheckForUpdatesCommand}"/>
         <MenuItem Header="About..."
             FontFamily="Arial" FontSize="12"
             Command="{Binding OpenAboutCommand}"/>

--- a/Program.cs
+++ b/Program.cs
@@ -1,16 +1,21 @@
 ﻿using System;
 using Avalonia;
+using Velopack;
 
 namespace vTFMS
 {
     internal sealed class Program
     {
-        // Initialization code. Don't use any Avalonia, third-party APIs or any
-        // SynchronizationContext-reliant code before AppMain is called: things aren't initialized
-        // yet and stuff might break.
         [STAThread]
-        public static void Main(string[] args) => BuildAvaloniaApp()
-            .StartWithClassicDesktopLifetime(args);
+        public static void Main(string[] args)
+        {
+            // MUST be the first thing that runs — Velopack uses this to
+            // apply pending updates before Avalonia initializes.
+            VelopackApp.Build().Run();
+
+            BuildAvaloniaApp()
+                .StartWithClassicDesktopLifetime(args);
+        }
 
         // Avalonia configuration, don't remove; also used by visual designer.
         public static AppBuilder BuildAvaloniaApp()

--- a/Services/IUpdateService.cs
+++ b/Services/IUpdateService.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using Velopack.Sources;
+
+namespace vTFMS.Services;
+
+public interface IUpdateService
+{
+    Task<Velopack.UpdateInfo?> CheckForUpdatesAsync();
+    Task DownloadAndApplyUpdateAsync(Velopack.UpdateInfo updateInfo);
+}

--- a/Services/UpdateService.cs
+++ b/Services/UpdateService.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Threading.Tasks;
+using Velopack;
+using Velopack.Sources;
+
+namespace vTFMS.Services;
+
+public class UpdateService : IUpdateService
+{
+    private readonly UpdateManager _updateManager;
+
+    public UpdateService()
+    {
+        _updateManager = new UpdateManager(
+            new GithubSource(
+                repoUrl: "https://github.com/Virtual-Traffic-Situation-Display/vtsd",
+                accessToken: null,   // public repo — no token needed
+                prerelease: true    // set to true if you want beta releases offered
+            )
+        );
+    }
+
+    public async Task<UpdateInfo?> CheckForUpdatesAsync()
+    {
+        // If not installed via Velopack (e.g. running from dotnet run),
+        // IsInstalled will be false and we skip the check gracefully.
+        if (!_updateManager.IsInstalled)
+            return null;
+
+        return await _updateManager.CheckForUpdatesAsync();
+    }
+
+    public async Task DownloadAndApplyUpdateAsync(UpdateInfo updateInfo)
+    {
+        await _updateManager.DownloadUpdatesAsync(updateInfo);
+
+        // Applies the update and restarts the app. Does not return.
+        _updateManager.ApplyUpdatesAndRestart(updateInfo);
+    }
+}

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Reflection;
+using vTFMS.Helpers;
 using vTFMS.Models;
 using vTFMS.Services;
 using vTFMS.ViewModels;
@@ -22,6 +23,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private readonly IWeatherService _weatherService;
     private readonly IMapDataService _mapDataService;
     private readonly IFontService _fontService;
+    private readonly IUpdateService _updateService;
     private readonly Window _mainWindow;
 
 
@@ -83,6 +85,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
                          IProfileService profileService,
                          IWeatherService weatherService,
                          IFontService fontService,
+                         IUpdateService updateService,
                          Window mainWindow)
     {
         _panelManager = panelManager;
@@ -90,6 +93,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
         _weatherService = weatherService;
         _fontService = fontService;
         _mapDataService = mapDataService;
+        _updateService = updateService;
         _mainWindow = mainWindow;
         TsdViewModel = new TsdViewModel(mapDataService, vatsimService, weatherService);
 
@@ -173,6 +177,35 @@ public partial class MainViewModel : ObservableObject, IDisposable
     {
         var about = new AboutWindow(AppVersion);
         about.Show(_mainWindow);
+    }
+
+    [RelayCommand]
+    private async Task CheckForUpdates()
+    {
+        var updateInfo = await _updateService.CheckForUpdatesAsync();
+    
+        if (updateInfo == null)
+        {
+            // No update found (or running in dev mode) — tell the user
+            await MessageBoxHelper.ShowInfoAsync(
+                _mainWindow,
+                title: "No Updates",
+                message: "You're already on the latest version.");
+            return;
+        }
+    
+        var newVersion = updateInfo.TargetFullRelease.Version;
+    
+        var confirmed = await MessageBoxHelper.ShowConfirmAsync(
+            _mainWindow,
+            title: "Update Available",
+            message: $"Version {newVersion} is available. Download and install now?\n\nThe app will restart automatically.");
+    
+        if (!confirmed)
+            return;
+    
+        await _updateService.DownloadAndApplyUpdateAsync(updateInfo);
+        // Does not return — app restarts here
     }
 
     [RelayCommand]

--- a/vTFMS.csproj
+++ b/vTFMS.csproj
@@ -60,6 +60,7 @@
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
+    <PackageReference Include="Velopack" Version="0.0.1298" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Integrates [Velopack](https://velopack.io) to provide a native installer and in-app auto-updater for all three supported platforms.

## What's new

- **`Program.cs`** — `VelopackApp.Build().Run()` runs before Avalonia initializes, enabling pending update application on launch
- **`Services/IUpdateService` + `Services/UpdateService`** — wraps Velopack's `UpdateManager`, pointed at GitHub Releases as the update source. Pre-release flag set to `true` for the current beta channel
- **`Helpers/MessageBoxHelper`** — lightweight confirm/info dialog utility used by the update flow (and available for future use elsewhere)
- **`ViewModels/MainViewModel`** — new `CheckForUpdatesCommand` handles the full update flow: checks GitHub, prompts the user, downloads, and applies on restart
- **`Views/MainWindow.axaml`** — new **Help → Check for Updates** menu item
- **`.github/workflows/release.yml`** — replaces the manual zip step with `vpk pack`, producing platform-native output per target:
  - Windows → `Setup.exe`
  - Linux → `.AppImage`
  - macOS → `.dmg`

## Notes

- The update check no-ops gracefully when running outside a Velopack install (i.e. `dotnet run` in dev) — `IsInstalled` will be `false` and nothing happens
- `prerelease: true` in `UpdateService` should be flipped to `false` when a stable `v1.0.0` is tagged
- The GitHub Release workflow now sets `prerelease: true` on created releases to match