### PR TITLE
feat: add flight details panel on left click

### DIFF
--- a/Models/VatsimPilot.cs
+++ b/Models/VatsimPilot.cs
@@ -18,7 +18,24 @@ public class VatsimPilot
     public string MatchedFilterColor { get; set; } = "#FFFFFF";
     public bool MatchedDrawRoute { get; set; } = false;
     public bool MatchedShowRoute { get; set; } = false;
-    
+
+    // Additional VATSIM API fields
+    public int Cid { get; set; }
+    public string PilotName { get; set; } = string.Empty;
+    public string Transponder { get; set; } = string.Empty;
+    public string FlightRules { get; set; } = string.Empty;
+    public string AircraftFull { get; set; } = string.Empty;
+    public string Alternate { get; set; } = string.Empty;
+    public string FiledAltitude { get; set; } = string.Empty;
+    public string DepTime { get; set; } = string.Empty;
+    public string EnrouteTime { get; set; } = string.Empty;
+    public string FuelTime { get; set; } = string.Empty;
+    public string Remarks { get; set; } = string.Empty;
+    public string LogonTime { get; set; } = string.Empty;
+    public string AssignedTransponder { get; set; } = string.Empty;
+    public string CruiseTas { get; set; } = string.Empty;
+    public string Server { get; set; } = string.Empty;
+
     // Per-pilot overrides (set via right-click context menu)
     public bool ShowDataBlock { get; set; } = false;
     public bool ShowOrgDest { get; set; } = false;

--- a/Services/VatsimService.cs
+++ b/Services/VatsimService.cs
@@ -111,6 +111,24 @@ public class VatsimService : IVatsimService, IDisposable
                 existing.Departure = pilot.Departure;
                 existing.Arrival = pilot.Arrival;
                 existing.Route = pilot.Route;
+
+                // Merge additional fields
+                existing.Cid = pilot.Cid;
+                existing.PilotName = pilot.PilotName;
+                existing.Transponder = pilot.Transponder;
+                existing.FlightRules = pilot.FlightRules;
+                existing.AircraftFull = pilot.AircraftFull;
+                existing.Alternate = pilot.Alternate;
+                existing.FiledAltitude = pilot.FiledAltitude;
+                existing.DepTime = pilot.DepTime;
+                existing.EnrouteTime = pilot.EnrouteTime;
+                existing.FuelTime = pilot.FuelTime;
+                existing.Remarks = pilot.Remarks;
+                existing.LogonTime = pilot.LogonTime;
+                existing.AssignedTransponder = pilot.AssignedTransponder;
+                existing.CruiseTas = pilot.CruiseTas;
+                existing.Server = pilot.Server;
+
                 existing.RecordSpeed(pilot.GroundSpeed);
                 newCache[pilot.Callsign] = existing;
             }
@@ -181,6 +199,16 @@ public class VatsimService : IVatsimService, IDisposable
                 string departure = string.Empty;
                 string aircraftType = string.Empty;
                 string route = string.Empty;
+                string flightRules = string.Empty;
+                string aircraftFull = string.Empty;
+                string alternate = string.Empty;
+                string filedAltitude = string.Empty;
+                string depTime = string.Empty;
+                string enrouteTime = string.Empty;
+                string fuelTime = string.Empty;
+                string remarks = string.Empty;
+                string assignedTransponder = string.Empty;
+                string cruiseTas = string.Empty;
 
                 if (p.TryGetProperty("flight_plan", out var fp) &&
                     fp.ValueKind == JsonValueKind.Object)
@@ -193,6 +221,27 @@ public class VatsimService : IVatsimService, IDisposable
                         ? ac.GetString() ?? string.Empty : string.Empty;
                     route = fp.TryGetProperty("route", out var rt)
                         ? rt.GetString() ?? string.Empty : string.Empty;
+                    flightRules = fp.TryGetProperty("flight_rules", out var fr)
+                        ? fr.GetString() ?? string.Empty : string.Empty;
+                    aircraftFull = fp.TryGetProperty("aircraft", out var acFull)
+                        ? acFull.GetString() ?? string.Empty : string.Empty;
+                    alternate = fp.TryGetProperty("alternate", out var alt2)
+                        ? alt2.GetString() ?? string.Empty : string.Empty;
+                    filedAltitude = fp.TryGetProperty("altitude", out var fAlt)
+                        ? fAlt.GetString() ?? string.Empty : string.Empty;
+                    depTime = fp.TryGetProperty("deptime", out var dt)
+                        ? dt.GetString() ?? string.Empty : string.Empty;
+                    enrouteTime = fp.TryGetProperty("enroute_time", out var et)
+                        ? et.GetString() ?? string.Empty : string.Empty;
+                    fuelTime = fp.TryGetProperty("fuel_time", out var ft)
+                        ? ft.GetString() ?? string.Empty : string.Empty;
+                    remarks = fp.TryGetProperty("remarks", out var rmk)
+                        ? rmk.GetString() ?? string.Empty : string.Empty;
+                    assignedTransponder = fp.TryGetProperty(
+                        "assigned_transponder", out var atp)
+                        ? atp.GetString() ?? string.Empty : string.Empty;
+                    cruiseTas = fp.TryGetProperty("cruise_tas", out var tas)
+                        ? tas.GetString() ?? string.Empty : string.Empty;
                 }
 
                 if (!ShouldIncludePilot(lat, lon, arrival, departure))
@@ -212,7 +261,29 @@ public class VatsimService : IVatsimService, IDisposable
                     AircraftType = aircraftType,
                     Departure = departure,
                     Arrival = arrival,
-                    Route = route
+                    Route = route,
+
+                    // Additional fields
+                    Cid = p.TryGetProperty("cid", out var cid)
+                        ? cid.GetInt32() : 0,
+                    PilotName = p.TryGetProperty("name", out var name)
+                        ? name.GetString() ?? string.Empty : string.Empty,
+                    Transponder = p.TryGetProperty("transponder", out var xpdr)
+                        ? xpdr.GetString() ?? string.Empty : string.Empty,
+                    Server = p.TryGetProperty("server", out var srv)
+                        ? srv.GetString() ?? string.Empty : string.Empty,
+                    LogonTime = p.TryGetProperty("logon_time", out var lt)
+                        ? lt.GetString() ?? string.Empty : string.Empty,
+                    FlightRules = flightRules,
+                    AircraftFull = aircraftFull,
+                    Alternate = alternate,
+                    FiledAltitude = filedAltitude,
+                    DepTime = depTime,
+                    EnrouteTime = enrouteTime,
+                    FuelTime = fuelTime,
+                    Remarks = remarks,
+                    AssignedTransponder = assignedTransponder,
+                    CruiseTas = cruiseTas
                 };
 
                 result.Add(pilot);

--- a/ViewModels/MainViewModel.cs
+++ b/ViewModels/MainViewModel.cs
@@ -32,6 +32,7 @@ public partial class MainViewModel : ObservableObject, IDisposable
     public TsdViewModel TsdViewModel { get; }
 
     private FlightCountPanelWindow? _flightCountWindow;
+    private FlightDetailWindow? _flightDetailWindow;
 
     [RelayCommand]
     private void ToggleFlightCount()
@@ -198,6 +199,25 @@ public partial class MainViewModel : ObservableObject, IDisposable
     private void OpenCustomizeFlightDisplay() =>
         _panelManager.OpenWithArgs(
             new CustomizeFlightDisplayWindow(TsdViewModel));
+
+    /// <summary>
+    /// Opens or updates the flight detail window for the given pilot.
+    /// Called from TsdView when a flight icon is left-clicked.
+    /// </summary>
+    public void OpenFlightDetail(VatsimPilot pilot)
+    {
+        if (_flightDetailWindow != null)
+        {
+            _flightDetailWindow.UpdatePilot(pilot);
+            _flightDetailWindow.Activate();
+            return;
+        }
+
+        _flightDetailWindow = new FlightDetailWindow(pilot);
+        _flightDetailWindow.Closed += (_, _) =>
+            _flightDetailWindow = null;
+        _flightDetailWindow.Show(_mainWindow);
+    }
 
     [RelayCommand]
     private async Task CheckForUpdates()

--- a/ViewModels/Panels/FlightDetailPanelViewModel.cs
+++ b/ViewModels/Panels/FlightDetailPanelViewModel.cs
@@ -1,0 +1,166 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using vTFMS.Models;
+
+namespace vTFMS.ViewModels.Panels;
+
+public partial class FlightDetailPanelViewModel : BasePanelViewModel
+{
+    [ObservableProperty]
+    private string _callsign = string.Empty;
+
+    [ObservableProperty]
+    private string _pilotName = string.Empty;
+
+    [ObservableProperty]
+    private int _cid;
+
+    [ObservableProperty]
+    private string _aircraftType = string.Empty;
+
+    [ObservableProperty]
+    private string _aircraftFull = string.Empty;
+
+    [ObservableProperty]
+    private string _departure = string.Empty;
+
+    [ObservableProperty]
+    private string _arrival = string.Empty;
+
+    [ObservableProperty]
+    private string _alternate = string.Empty;
+
+    [ObservableProperty]
+    private string _flightRules = string.Empty;
+
+    [ObservableProperty]
+    private string _route = string.Empty;
+
+    [ObservableProperty]
+    private string _currentAltitude = string.Empty;
+
+    [ObservableProperty]
+    private string _filedAltitude = string.Empty;
+
+    [ObservableProperty]
+    private int _groundSpeed;
+
+    [ObservableProperty]
+    private int _heading;
+
+    [ObservableProperty]
+    private string _transponder = string.Empty;
+
+    [ObservableProperty]
+    private string _assignedTransponder = string.Empty;
+
+    [ObservableProperty]
+    private string _cruiseTas = string.Empty;
+
+    [ObservableProperty]
+    private string _depTime = string.Empty;
+
+    [ObservableProperty]
+    private string _enrouteTime = string.Empty;
+
+    [ObservableProperty]
+    private string _fuelTime = string.Empty;
+
+    [ObservableProperty]
+    private string _remarks = string.Empty;
+
+    [ObservableProperty]
+    private string _position = string.Empty;
+
+    [ObservableProperty]
+    private string _server = string.Empty;
+
+    [ObservableProperty]
+    private string _logonTime = string.Empty;
+
+    public FlightDetailPanelViewModel()
+    {
+        Title = "Flight Detail";
+    }
+
+    public void LoadPilot(VatsimPilot pilot)
+    {
+        Title = $"Flight Detail — {pilot.Callsign}";
+
+        Callsign = pilot.Callsign;
+        PilotName = pilot.PilotName;
+        Cid = pilot.Cid;
+        AircraftType = pilot.AircraftType;
+        AircraftFull = pilot.AircraftFull;
+        Departure = pilot.Departure;
+        Arrival = pilot.Arrival;
+        Alternate = pilot.Alternate;
+        FlightRules = pilot.FlightRules;
+        Route = pilot.Route;
+        FiledAltitude = FormatFiledAltitude(pilot.FiledAltitude);
+        CurrentAltitude = FormatCurrentAltitude(pilot.Altitude);
+        GroundSpeed = pilot.GroundSpeed;
+        Heading = pilot.Heading;
+        Transponder = pilot.Transponder;
+        AssignedTransponder = pilot.AssignedTransponder;
+        CruiseTas = pilot.CruiseTas;
+        DepTime = FormatTime(pilot.DepTime);
+        EnrouteTime = FormatDuration(pilot.EnrouteTime);
+        FuelTime = FormatDuration(pilot.FuelTime);
+        Remarks = pilot.Remarks;
+        Position = $"{pilot.Lat:F4}°, {pilot.Lon:F4}°";
+        Server = pilot.Server;
+        LogonTime = FormatLogonTime(pilot.LogonTime);
+    }
+
+    private static string FormatCurrentAltitude(int altitude)
+    {
+        return altitude >= 18000
+            ? $"FL{altitude / 100:000}"
+            : $"{altitude:N0} ft";
+    }
+
+    private static string FormatFiledAltitude(string filed)
+    {
+        if (string.IsNullOrWhiteSpace(filed)) return string.Empty;
+
+        // VATSIM often sends the altitude as a plain number string
+        if (int.TryParse(filed, out int alt))
+        {
+            return alt >= 18000
+                ? $"FL{alt / 100:000}"
+                : $"{alt:N0} ft";
+        }
+
+        return filed;
+    }
+
+    private static string FormatTime(string hhmm)
+    {
+        if (string.IsNullOrWhiteSpace(hhmm) || hhmm.Length < 4)
+            return hhmm;
+
+        return $"{hhmm[..2]}:{hhmm[2..]}z";
+    }
+
+    private static string FormatDuration(string hhmm)
+    {
+        if (string.IsNullOrWhiteSpace(hhmm) || hhmm.Length < 4)
+            return hhmm;
+
+        return $"{hhmm[..2]}h {hhmm[2..]}m";
+    }
+
+    private static string FormatLogonTime(string iso)
+    {
+        if (string.IsNullOrWhiteSpace(iso)) return string.Empty;
+
+        if (System.DateTime.TryParse(iso, null,
+            System.Globalization.DateTimeStyles.RoundtripKind,
+            out var dt))
+        {
+            return dt.ToString("HH:mm:ss") + "z";
+        }
+
+        return iso;
+    }
+}

--- a/Views/Panels/FlightDetailWindow.axaml
+++ b/Views/Panels/FlightDetailWindow.axaml
@@ -1,0 +1,214 @@
+<panels:BasePanelWindow
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:panels="using:vTFMS.Views.Panels"
+    xmlns:vm="using:vTFMS.ViewModels.Panels"
+    x:Class="vTFMS.Views.Panels.FlightDetailWindow"
+    x:DataType="vm:FlightDetailPanelViewModel"
+    Width="440" Height="520"
+    MinWidth="360" MinHeight="400"
+    Title="{Binding Title}">
+
+  <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                VerticalScrollBarVisibility="Auto">
+    <StackPanel Margin="12,8" Spacing="10">
+
+      <!-- Identity -->
+      <Border Background="#22000000" CornerRadius="4" Padding="10,8">
+        <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto"
+              RowSpacing="4" ColumnSpacing="12">
+
+          <TextBlock Grid.Row="0" Grid.Column="0"
+                     Text="Callsign" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="0" Grid.Column="1"
+                     Text="{Binding Callsign}"
+                     FontWeight="Bold" FontSize="14"/>
+
+          <TextBlock Grid.Row="1" Grid.Column="0"
+                     Text="Pilot" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="1" Grid.Column="1"
+                     Text="{Binding PilotName}" FontSize="11"/>
+
+          <TextBlock Grid.Row="2" Grid.Column="0"
+                     Text="CID" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="2" Grid.Column="1"
+                     Text="{Binding Cid}" FontSize="11"/>
+        </Grid>
+      </Border>
+
+      <!-- Flight Plan -->
+      <TextBlock Text="FLIGHT PLAN" FontWeight="Bold" FontSize="10"
+                 Foreground="#777777" Margin="0,2,0,0"/>
+      <Border Background="#22000000" CornerRadius="4" Padding="10,8">
+        <Grid ColumnDefinitions="Auto,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto"
+              RowSpacing="4" ColumnSpacing="12">
+
+          <TextBlock Grid.Row="0" Grid.Column="0"
+                     Text="Rules" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="0" Grid.Column="1"
+                     Text="{Binding FlightRules}" FontSize="11"/>
+
+          <TextBlock Grid.Row="1" Grid.Column="0"
+                     Text="Aircraft" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <StackPanel Grid.Row="1" Grid.Column="1" Spacing="1">
+            <TextBlock Text="{Binding AircraftType}" FontSize="11"
+                       FontWeight="SemiBold"/>
+            <TextBlock Text="{Binding AircraftFull}" FontSize="10"
+                       Foreground="#666666" TextWrapping="Wrap"/>
+          </StackPanel>
+
+          <TextBlock Grid.Row="2" Grid.Column="0"
+                     Text="Departure" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="2" Grid.Column="1"
+                     Text="{Binding Departure}" FontSize="11"/>
+
+          <TextBlock Grid.Row="3" Grid.Column="0"
+                     Text="Arrival" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="3" Grid.Column="1"
+                     Text="{Binding Arrival}" FontSize="11"/>
+
+          <TextBlock Grid.Row="4" Grid.Column="0"
+                     Text="Alternate" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="4" Grid.Column="1"
+                     Text="{Binding Alternate}" FontSize="11"/>
+
+          <TextBlock Grid.Row="5" Grid.Column="0"
+                     Text="Filed Alt" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="5" Grid.Column="1"
+                     Text="{Binding FiledAltitude}" FontSize="11"/>
+        </Grid>
+      </Border>
+
+      <!-- Position -->
+      <TextBlock Text="POSITION" FontWeight="Bold" FontSize="10"
+                 Foreground="#777777" Margin="0,2,0,0"/>
+      <Border Background="#22000000" CornerRadius="4" Padding="10,8">
+        <Grid ColumnDefinitions="Auto,*,Auto,*"
+              RowDefinitions="Auto,Auto,Auto"
+              RowSpacing="4" ColumnSpacing="12">
+
+          <TextBlock Grid.Row="0" Grid.Column="0"
+                     Text="Altitude" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="0" Grid.Column="1"
+                     Text="{Binding CurrentAltitude}" FontSize="11"/>
+          <TextBlock Grid.Row="0" Grid.Column="2"
+                     Text="Heading" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="0" Grid.Column="3"
+                     Text="{Binding Heading, StringFormat={}{0}°}" FontSize="11"/>
+
+          <TextBlock Grid.Row="1" Grid.Column="0"
+                     Text="Speed" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="1" Grid.Column="1"
+                     Text="{Binding GroundSpeed, StringFormat={}{0} kts}" FontSize="11"/>
+          <TextBlock Grid.Row="1" Grid.Column="2"
+                     Text="TAS" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="1" Grid.Column="3"
+                     Text="{Binding CruiseTas}" FontSize="11"/>
+
+          <TextBlock Grid.Row="2" Grid.Column="0"
+                     Text="Position" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="3"
+                     Text="{Binding Position}" FontSize="11"/>
+        </Grid>
+      </Border>
+
+      <!-- Transponder -->
+      <TextBlock Text="TRANSPONDER" FontWeight="Bold" FontSize="10"
+                 Foreground="#777777" Margin="0,2,0,0"/>
+      <Border Background="#22000000" CornerRadius="4" Padding="10,8">
+        <Grid ColumnDefinitions="Auto,*,Auto,*"
+              RowDefinitions="Auto"
+              RowSpacing="4" ColumnSpacing="12">
+
+          <TextBlock Grid.Row="0" Grid.Column="0"
+                     Text="Squawk" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="0" Grid.Column="1"
+                     Text="{Binding Transponder}" FontSize="11"/>
+          <TextBlock Grid.Row="0" Grid.Column="2"
+                     Text="Assigned" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="0" Grid.Column="3"
+                     Text="{Binding AssignedTransponder}" FontSize="11"/>
+        </Grid>
+      </Border>
+
+      <!-- Times -->
+      <TextBlock Text="TIMES" FontWeight="Bold" FontSize="10"
+                 Foreground="#777777" Margin="0,2,0,0"/>
+      <Border Background="#22000000" CornerRadius="4" Padding="10,8">
+        <Grid ColumnDefinitions="Auto,*,Auto,*"
+              RowDefinitions="Auto,Auto"
+              RowSpacing="4" ColumnSpacing="12">
+
+          <TextBlock Grid.Row="0" Grid.Column="0"
+                     Text="Dep Time" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="0" Grid.Column="1"
+                     Text="{Binding DepTime}" FontSize="11"/>
+          <TextBlock Grid.Row="0" Grid.Column="2"
+                     Text="Enroute" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="0" Grid.Column="3"
+                     Text="{Binding EnrouteTime}" FontSize="11"/>
+
+          <TextBlock Grid.Row="1" Grid.Column="0"
+                     Text="Fuel" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="1" Grid.Column="1"
+                     Text="{Binding FuelTime}" FontSize="11"/>
+          <TextBlock Grid.Row="1" Grid.Column="2"
+                     Text="Logon" FontWeight="SemiBold"
+                     Foreground="#555555" FontSize="11"/>
+          <TextBlock Grid.Row="1" Grid.Column="3"
+                     Text="{Binding LogonTime}" FontSize="11"/>
+        </Grid>
+      </Border>
+
+      <!-- Route -->
+      <TextBlock Text="ROUTE" FontWeight="Bold" FontSize="10"
+                 Foreground="#777777" Margin="0,2,0,0"/>
+      <Border Background="#22000000" CornerRadius="4" Padding="10,8">
+        <TextBlock Text="{Binding Route}" FontSize="11"
+                   TextWrapping="Wrap"/>
+      </Border>
+
+      <!-- Remarks -->
+      <TextBlock Text="REMARKS" FontWeight="Bold" FontSize="10"
+                 Foreground="#777777" Margin="0,2,0,0"/>
+      <Border Background="#22000000" CornerRadius="4" Padding="10,8">
+        <TextBlock Text="{Binding Remarks}" FontSize="11"
+                   TextWrapping="Wrap"/>
+      </Border>
+
+      <!-- Server -->
+      <Border Background="#22000000" CornerRadius="4" Padding="10,4"
+              Margin="0,0,0,4">
+        <TextBlock FontSize="10" Foreground="#888888"
+                   HorizontalAlignment="Right">
+          <TextBlock.Text>
+            <MultiBinding StringFormat="Server: {0}">
+              <Binding Path="Server"/>
+            </MultiBinding>
+          </TextBlock.Text>
+        </TextBlock>
+      </Border>
+
+    </StackPanel>
+  </ScrollViewer>
+
+</panels:BasePanelWindow>

--- a/Views/Panels/FlightDetailWindow.axaml.cs
+++ b/Views/Panels/FlightDetailWindow.axaml.cs
@@ -1,0 +1,26 @@
+using vTFMS.Models;
+using vTFMS.ViewModels.Panels;
+
+namespace vTFMS.Views.Panels;
+
+public partial class FlightDetailWindow : BasePanelWindow
+{
+    private readonly FlightDetailPanelViewModel _vm;
+
+    public FlightDetailWindow()
+    {
+        _vm = new FlightDetailPanelViewModel();
+        DataContext = _vm;
+        InitializeComponent();
+    }
+
+    public FlightDetailWindow(VatsimPilot pilot) : this()
+    {
+        _vm.LoadPilot(pilot);
+    }
+
+    public void UpdatePilot(VatsimPilot pilot)
+    {
+        _vm.LoadPilot(pilot);
+    }
+}

--- a/Views/TsdRadarControl.Input.cs
+++ b/Views/TsdRadarControl.Input.cs
@@ -9,7 +9,7 @@ namespace vTFMS.Views;
 public partial class TsdRadarControl
 {
     // =========================================================================
-    // Input — Pointer (hover, right-click context menus)
+    // Input — Pointer (hover, left-click detail, right-click context menus)
     // =========================================================================
 
     protected override void OnPointerMoved(PointerEventArgs e)
@@ -51,11 +51,34 @@ public partial class TsdRadarControl
         base.OnPointerPressed(e);
 
         var point = e.GetCurrentPoint(this);
-        if (!point.Properties.IsRightButtonPressed) return;
-
         var clickPos = point.Position;
         var width = Bounds.Width;
         var height = Bounds.Height;
+
+        // ── Left-click: open flight detail ─────────────────────
+        if (point.Properties.IsLeftButtonPressed)
+        {
+            foreach (var pilot in VisiblePilots)
+            {
+                if (pilot.IsHidden) continue;
+                var pt = LatLonToScreen(pilot.Lat, pilot.Lon, width, height);
+                double dx = clickPos.X - pt.X;
+                double dy = clickPos.Y - pt.Y;
+
+                if (Math.Sqrt(dx * dx + dy * dy) <= 10.0)
+                {
+                    FlightDetailRequested?.Invoke(this, pilot);
+                    e.Handled = true;
+                    return;
+                }
+            }
+
+            // Left-click on empty space — no action
+            return;
+        }
+
+        // ── Right-click: context menus ─────────────────────────
+        if (!point.Properties.IsRightButtonPressed) return;
 
         // ── Hit-test 1: Flight icons ─────────────────────────
         foreach (var pilot in VisiblePilots)
@@ -195,6 +218,15 @@ public partial class TsdRadarControl
             colorMenu.Items.Add(colorItem);
         }
         menu.Items.Add(colorMenu);
+
+        menu.Items.Add(new Separator());
+
+        var detailItem = new MenuItem { Header = "Flight Detail..." };
+        detailItem.Click += (_, _) =>
+        {
+            FlightDetailRequested?.Invoke(this, pilot);
+        };
+        menu.Items.Add(detailItem);
 
         menu.Items.Add(new Separator());
 

--- a/Views/TsdRadarControl.cs
+++ b/Views/TsdRadarControl.cs
@@ -103,6 +103,9 @@ public partial class TsdRadarControl : Control
     /// (e.g. "SelectFlights", "ShowMapItem", "RangeRings").</summary>
     public event EventHandler<string>? GenericMenuCommandRequested;
 
+    /// <summary>Raised when a flight icon is left-clicked to open detail view.</summary>
+    public event EventHandler<VatsimPilot>? FlightDetailRequested;
+
     // =========================================================================
     // Constructor
     // =========================================================================

--- a/Views/TsdView.axaml.cs
+++ b/Views/TsdView.axaml.cs
@@ -35,6 +35,8 @@ public partial class TsdView : UserControl
             _radarControl.MapItemRemoveRequested += OnMapItemRemoveRequested;
             _radarControl.GenericMenuCommandRequested -= OnGenericMenuCommand;
             _radarControl.GenericMenuCommandRequested += OnGenericMenuCommand;
+            _radarControl.FlightDetailRequested -= OnFlightDetailRequested;
+            _radarControl.FlightDetailRequested += OnFlightDetailRequested;
             System.Diagnostics.Debug.WriteLine(
                 "TsdView: subscribed to RadarRefreshRequested");
         }
@@ -81,5 +83,13 @@ public partial class TsdView : UserControl
                 mainVm.OpenFindFlightCommand.Execute(null);
                 break;
         }
+    }
+
+    private void OnFlightDetailRequested(object? sender, VatsimPilot pilot)
+    {
+        var mainWindow = this.FindAncestorOfType<Window>();
+        if (mainWindow?.DataContext is not MainViewModel mainVm) return;
+
+        mainVm.OpenFlightDetail(pilot);
     }
 }

--- a/vTFMS.csproj
+++ b/vTFMS.csproj
@@ -6,7 +6,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <AvaloniaUseCompiledBindingsByDefault>true</AvaloniaUseCompiledBindingsByDefault>
     <NoWarn>$(NoWarn);CS0108</NoWarn>
-    <Version>0.1.0-beta.1</Version>
+    <Version>0.1.0-beta.2</Version>
     <SelfContained>true</SelfContained>
   </PropertyGroup>
 

--- a/vTFMS.csproj
+++ b/vTFMS.csproj
@@ -8,7 +8,6 @@
     <NoWarn>$(NoWarn);CS0108</NoWarn>
     <Version>0.1.0-beta.1</Version>
     <SelfContained>true</SelfContained>
-    <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Left-click aircraft to open Flight Detail window

Fixes #88

## Summary

Left-clicking an aircraft icon on the radar opens a Flight Detail window showing all available VATSIM data for that flight. Clicking a different aircraft updates the same window rather than opening a second one.

## Changes

### New: Flight Detail Window
- **FlightDetailWindow** — read-only panel displaying pilot identity, flight plan, position, transponder, times, route, and remarks
- **FlightDetailPanelViewModel** — formats raw VATSIM data for display (altitude as FL/ft, times as HH:MMz, coordinates as decimal degrees)
- Extends `BasePanelWindow` for consistent look (pinnable, draggable, custom title bar)
- Scrollable layout for flights with long routes or remarks

### Expanded VATSIM data capture
- **VatsimPilot** model now includes 14 additional fields: CID, pilot name, transponder, flight rules, full ICAO equipment, alternate airport, filed altitude, departure time, enroute time, fuel time, remarks, logon time, assigned transponder, cruise TAS, server
- **VatsimService.Parse()** extracts all new fields from the v3 JSON feed
- **VatsimService.MergeWithCache()** preserves new fields across data refreshes

### Input handling
- Left-click on aircraft icon fires `FlightDetailRequested` event → opens/updates Flight Detail window
- Left-click on empty space is a no-op (does not interfere with drag or other interactions)
- "Flight Detail..." also added to right-click context menu as an alternate access path

### Wiring
- `TsdRadarControl` → new `FlightDetailRequested` event
- `TsdView` → subscribes and forwards to `MainViewModel.OpenFlightDetail()`
- `MainViewModel` → manages single-instance window (update existing or create new)

## Testing
- [ ] Left-click aircraft → detail window opens with correct data
- [ ] Left-click different aircraft → same window updates
- [ ] Close window → left-click opens fresh window
- [ ] Right-click → "Flight Detail..." menu item works
- [ ] All fields populated (verify with a flight that has a filed plan)
- [ ] Flight without a flight plan shows empty fields gracefully
- [ ] Left-click on empty space does nothing
- [ ] Existing right-click context menu still works
- [ ] Hover data blocks still work